### PR TITLE
mergepbxを導入する

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.pbxproj merge=mergepbx

--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@
 1. 下記のコマンドを実行([詳細](http://qiita.com/kaneshin/items/1deebde685c973fda6b8))
 
 ```
-curl -s https://gist.githubusercontent.com/kaneshin/40d9331941682bf46f5d/raw/42e2a7df2d8dbf6c956edcd3fd1c332e3364f573/install_mergepbx.sh | sh
+brew install mergepbx
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # sunset project
 
+私の人生がここにある
+
+## 開発環境構築
+
+### carthage
+
+1. Carthageをインストールする
+2. リポジトリをクローン
+3. ルートで`carthage update --platform iOS`
+
+### mergepbx
+
+1. 下記のコマンドを実行([詳細](http://qiita.com/kaneshin/items/1deebde685c973fda6b8))
+
+```
+curl -s https://gist.githubusercontent.com/kaneshin/40d9331941682bf46f5d/raw/42e2a7df2d8dbf6c956edcd3fd1c332e3364f573/install_mergepbx.sh | sh
+```
+


### PR DESCRIPTION
## 背景

プロジェクトファイルのコンフリクトが避けて通れなさそうなので、事前に対策をする。
[mergepbx](https://github.com/simonwagner/mergepbx)を使って解決をする。
### 参考

[project.pbxproj のコンフリクトを解決するために mergepbx を利用する
](http://kainokikaede.hatenablog.com/entry/2014/12/01/211450)
