### PR TITLE
ナビゲーションバーにカレンダーの移動ボタンをつける

### DIFF
--- a/sunset/Classes/Controllers/CalendarViewController.swift
+++ b/sunset/Classes/Controllers/CalendarViewController.swift
@@ -53,7 +53,6 @@ class CalendarViewController: UIViewController, UICollectionViewDataSource, UICo
         calendarCollectionView.dataSource = self
         calendarCollectionView.backgroundColor = UIColor.white
         
-        
         let TapPrevBtnNotification = Notification.Name("TapPrevBtn")
         let TapNextBtnNotification = Notification.Name("TapNextBtn")
         NotificationCenter.default.addObserver(self, selector: #selector(self.updatePrevView(_:)), name: TapPrevBtnNotification, object: nil)
@@ -128,7 +127,6 @@ class CalendarViewController: UIViewController, UICollectionViewDataSource, UICo
         NotificationCenter.default.post(name: TapCalendarCellNotification, object: nil)
     }
 
-    
     //headerの月を変更
     func changeHeaderTitle(_ date: Date) -> String {
         let formatter: DateFormatter = DateFormatter()

--- a/sunset/Classes/Controllers/CalendarViewController.swift
+++ b/sunset/Classes/Controllers/CalendarViewController.swift
@@ -22,7 +22,6 @@ class CalendarViewController: UIViewController, UICollectionViewDataSource, UICo
     let appDelegate:AppDelegate = UIApplication.shared.delegate as! AppDelegate
     let TapCalendarCellNotification = Notification.Name("TapCelandarCell")
     
-    
     @IBOutlet var swipeLeftGesture: UISwipeGestureRecognizer!
     @IBOutlet var swipeRightGesture: UISwipeGestureRecognizer!
     
@@ -53,6 +52,12 @@ class CalendarViewController: UIViewController, UICollectionViewDataSource, UICo
         calendarCollectionView.delegate = self
         calendarCollectionView.dataSource = self
         calendarCollectionView.backgroundColor = UIColor.white
+        
+        
+        let TapPrevBtnNotification = Notification.Name("TapPrevBtn")
+        let TapNextBtnNotification = Notification.Name("TapNextBtn")
+        NotificationCenter.default.addObserver(self, selector: #selector(self.updatePrevView(_:)), name: TapPrevBtnNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(self.updateNextView(_:)), name: TapNextBtnNotification, object: nil)
     }
     
     override func didReceiveMemoryWarning() {
@@ -141,4 +146,17 @@ class CalendarViewController: UIViewController, UICollectionViewDataSource, UICo
         appDelegate.targetDate = date + "-" + day
         NotificationCenter.default.post(name: TapCalendarCellNotification, object: nil)
     }
+    
+    @objc func updatePrevView(_ notification: Notification) {
+        selectedDate = dateManager.prevMonth(selectedDate)
+        self.parent?.title = changeHeaderTitle(selectedDate)
+        calendarCollectionView.reloadData()
+    }
+    
+    @objc func updateNextView(_ notification: Notification) {
+        selectedDate = dateManager.nextMonth(selectedDate)
+        self.parent?.title = changeHeaderTitle(selectedDate)
+        calendarCollectionView.reloadData()
+    }
+    
 }

--- a/sunset/Classes/Controllers/ViewController.swift
+++ b/sunset/Classes/Controllers/ViewController.swift
@@ -34,7 +34,6 @@ class ViewController: UIViewController {
         //print(date)
     }
     
-    
     @IBAction func tappedNextMonthBtn(_ sender: UIButton) {
         let thisDate = generateTargetDate()
         let nextDate: Date = formatter.date(from: thisDate)!.monthLaterDate()

--- a/sunset/Classes/Controllers/ViewController.swift
+++ b/sunset/Classes/Controllers/ViewController.swift
@@ -28,17 +28,13 @@ class ViewController: UIViewController {
         let thisDate = generateTargetDate()
         let prevDate: Date = formatter.date(from: thisDate)!.monthAgoDate()
         appDelegate.targetDate = formatter.string(from: prevDate)
-        print(appDelegate.targetDate)
         NotificationCenter.default.post(name: TapPrevBtnNotification, object: nil)
-        //let date: Date = formatter.date(from: appDelegate.targetDate!)
-        //print(date)
     }
     
     @IBAction func tappedNextMonthBtn(_ sender: UIButton) {
         let thisDate = generateTargetDate()
         let nextDate: Date = formatter.date(from: thisDate)!.monthLaterDate()
         appDelegate.targetDate = formatter.string(from: nextDate)
-        print(appDelegate.targetDate)
         NotificationCenter.default.post(name: TapNextBtnNotification, object: nil)
     }
     

--- a/sunset/Classes/Controllers/ViewController.swift
+++ b/sunset/Classes/Controllers/ViewController.swift
@@ -1,15 +1,15 @@
-//
-//  ViewController.swift
-//  sunset
-//
-//  Created by usr0600429 on 2016/09/08.
-//  Copyright © 2016年 GMO Pepabo. All rights reserved.
-//
-
 import UIKit
 
 class ViewController: UIViewController {
 
+    @IBOutlet weak var headerPrevBtn: UIBarButtonItem!
+    @IBOutlet weak var headerNextBtn: UIBarButtonItem!
+    
+    let appDelegate: AppDelegate = UIApplication.shared.delegate as! AppDelegate
+    let formatter = DateFormatter()
+    let TapPrevBtnNotification = Notification.Name("TapPrevBtn")
+    let TapNextBtnNotification = Notification.Name("TapNextBtn")
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view, typically from a nib.
@@ -23,6 +23,36 @@ class ViewController: UIViewController {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.
     }
-
+    
+    @IBAction func tappedPrevMonthBtn(_ sender: UIButton) {
+        let thisDate = generateTargetDate()
+        let prevDate: Date = formatter.date(from: thisDate)!.monthAgoDate()
+        appDelegate.targetDate = formatter.string(from: prevDate)
+        print(appDelegate.targetDate)
+        NotificationCenter.default.post(name: TapPrevBtnNotification, object: nil)
+        //let date: Date = formatter.date(from: appDelegate.targetDate!)
+        //print(date)
+    }
+    
+    
+    @IBAction func tappedNextMonthBtn(_ sender: UIButton) {
+        let thisDate = generateTargetDate()
+        let nextDate: Date = formatter.date(from: thisDate)!.monthLaterDate()
+        appDelegate.targetDate = formatter.string(from: nextDate)
+        print(appDelegate.targetDate)
+        NotificationCenter.default.post(name: TapNextBtnNotification, object: nil)
+    }
+    
+    private func generateTargetDate() -> String {
+        formatter.dateFormat = "yyyy-MM-dd"
+        let thisDate = appDelegate.targetDate
+        let year:String = (thisDate?.components(separatedBy: "-")[0])!
+        let month:String = (thisDate?.components(separatedBy: "-")[1])!
+        let day:String = (thisDate?.components(separatedBy: "-")[2])!
+        
+        let thisDateString = year + "-" + month + "-" + day
+        return thisDateString
+    }
+    
 }
 

--- a/sunset/Storyboards/Main.storyboard
+++ b/sunset/Storyboards/Main.storyboard
@@ -43,7 +43,44 @@
                             <constraint firstItem="K7z-kq-uJq" firstAttribute="width" secondItem="qxZ-KF-Ddv" secondAttribute="width" id="xMh-SK-LUe"/>
                         </constraints>
                     </view>
-                    <navigationItem key="navigationItem" id="rRI-CP-B7K"/>
+                    <navigationItem key="navigationItem" id="rRI-CP-B7K">
+                        <barButtonItem key="leftBarButtonItem" style="done" id="ipd-Tl-rf2">
+                            <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="Eow-aZ-slC">
+                                <rect key="frame" x="16" y="7" width="83" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="25"/>
+                                <state key="normal" title="←">
+                                    <color key="titleColor" red="1" green="0.5" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                </state>
+                                <connections>
+                                    <action selector="tappedPrevMonthBtn:" destination="BYZ-38-t0r" eventType="touchUpInside" id="uT3-4i-Ufb"/>
+                                </connections>
+                            </button>
+                            <connections>
+                                <action selector="tappedPrevMonthBtn:" destination="BYZ-38-t0r" id="JUa-aZ-FLT"/>
+                            </connections>
+                        </barButtonItem>
+                        <barButtonItem key="rightBarButtonItem" style="done" id="Tgd-dE-bW3">
+                            <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="cj0-A2-FeU">
+                                <rect key="frame" x="276" y="7" width="83" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="25"/>
+                                <state key="normal" title="→">
+                                    <color key="titleColor" red="1" green="0.5" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                </state>
+                                <connections>
+                                    <action selector="tappedNextMonthBtn:" destination="BYZ-38-t0r" eventType="touchUpInside" id="taV-zy-ayo"/>
+                                </connections>
+                            </button>
+                            <connections>
+                                <action selector="tappedNextMonthBtn:" destination="BYZ-38-t0r" id="4Os-sl-qDh"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                    <connections>
+                        <outlet property="headerNextBtn" destination="Tgd-dE-bW3" id="oDc-sh-em6"/>
+                        <outlet property="headerPrevBtn" destination="ipd-Tl-rf2" id="PIa-07-lWa"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
@@ -62,7 +99,7 @@
                                 <rect key="frame" x="0.0" y="28" width="343" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="raw-TQ-c9E" id="5Vy-z7-txt">
-                                    <frame key="frameInset" width="343" height="43"/>
+                                    <frame key="frameInset" width="343" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </tableViewCellContentView>
                                 <connections>
@@ -151,7 +188,7 @@
                     </connections>
                 </swipeGestureRecognizer>
             </objects>
-            <point key="canvasLocation" x="1935.2" y="-12.818590704647677"/>
+            <point key="canvasLocation" x="2030" y="3"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="uiL-ej-m3Y">

--- a/sunsetUITests/sunsetUITests.swift
+++ b/sunsetUITests/sunsetUITests.swift
@@ -50,6 +50,7 @@ class sunsetUITests: XCTestCase {
 
     }
     
+    // swipe移動
     func testSwipeCalendar() {
         let app = XCUIApplication()
         formatter.dateFormat = "MMM yyyy"
@@ -61,19 +62,19 @@ class sunsetUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts[prevDateLabel].exists)
     }
     
+    // ボタン移動
     func testMoveCalendarByTappingBtn() {
         let app = XCUIApplication()
         formatter.dateFormat = "MMM yyyy"
         let nowDate: String = formatter.string(from: Date())
         let prevDate: String = changeDate(date: nowDate, check: "-")
         let nowDateLabel = app.staticTexts[nowDate]
-        let prevDateLabel = app.staticTexts[changeDate(date: nowDate, check: "-")]
+        let prevDateLabel = app.staticTexts[prevDate]
         XCTAssertTrue(nowDateLabel.exists)
         XCUIApplication().navigationBars[nowDate].buttons["←"].tap()
         XCTAssertTrue(prevDateLabel.exists)
         XCUIApplication().navigationBars[prevDate].buttons["→"].tap()
         XCTAssertTrue(nowDateLabel.exists)
-        
     }
     
     func testShowPosts() {

--- a/sunsetUITests/sunsetUITests.swift
+++ b/sunsetUITests/sunsetUITests.swift
@@ -1,6 +1,8 @@
 import XCTest
 
 class sunsetUITests: XCTestCase {
+    
+    let formatter = DateFormatter()
         
     override func setUp() {
         super.setUp()
@@ -50,7 +52,6 @@ class sunsetUITests: XCTestCase {
     
     func testSwipeCalendar() {
         let app = XCUIApplication()
-        let formatter = DateFormatter()
         formatter.dateFormat = "MMM yyyy"
         let now: String = formatter.string(from: Date())
         let nowDateLabel = app.staticTexts[now]
@@ -58,6 +59,21 @@ class sunsetUITests: XCTestCase {
         app.collectionViews.element.swipeRight()
         let prevDateLabel = changeDate(date: now, check: "-")
         XCTAssertTrue(app.staticTexts[prevDateLabel].exists)
+    }
+    
+    func testMoveCalendarByTappingBtn() {
+        let app = XCUIApplication()
+        formatter.dateFormat = "MMM yyyy"
+        let nowDate: String = formatter.string(from: Date())
+        let prevDate: String = changeDate(date: nowDate, check: "-")
+        let nowDateLabel = app.staticTexts[nowDate]
+        let prevDateLabel = app.staticTexts[changeDate(date: nowDate, check: "-")]
+        XCTAssertTrue(nowDateLabel.exists)
+        XCUIApplication().navigationBars[nowDate].buttons["←"].tap()
+        XCTAssertTrue(prevDateLabel.exists)
+        XCUIApplication().navigationBars[prevDate].buttons["→"].tap()
+        XCTAssertTrue(nowDateLabel.exists)
+        
     }
     
     func testShowPosts() {


### PR DESCRIPTION
### 概要

https://github.com/pepabo-mobile-app-training/sunset/pull/32 でのやり残しである、カレンダーの移動のアクションを、移動したヘッダー部分 (ナビゲーションバー) に復活させます
### やること
- ナビゲーションバーでの1ヶ月戻る、進むボタンの実装
- 削除していたボタン移動でのテストの復活
