### PR TITLE
表示されるカレンダーの日付をその月のみのものにする

### DIFF
--- a/sunset/AppDelegate.swift
+++ b/sunset/AppDelegate.swift
@@ -10,6 +10,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var targetDate: String?
     var calendarCellWidth: CGFloat?
     var calendarCellHeight: CGFloat?
+    var prevIndexPath: IndexPath?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.

--- a/sunset/Classes/Controllers/CalendarViewController.swift
+++ b/sunset/Classes/Controllers/CalendarViewController.swift
@@ -65,26 +65,19 @@ class CalendarViewController: UIViewController, UICollectionViewDataSource, UICo
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell: CalendarCell = collectionView.dequeueReusableCell(withReuseIdentifier: "calendarCell", for: indexPath) as! CalendarCell
         //テキストカラー
-        if (indexPath.row % 7 == 0) {
-            cell.textLabel.textColor = UIColor.red
-        } else if (indexPath.row % 7 == 6) {
-            cell.textLabel.textColor = UIColor.blue
-        } else {
-            cell.textLabel.textColor = UIColor.white
-        }
+        cell.textLabel.textColor = dateAttributes.choiceDaysColor(row: indexPath.row)
         let day: String = dateManager.ShowDayIfInThisMonth(indexPath.row)
+        // その月の日付かどうかの振り分け
         switch day {
         case "":
             cell.textLabel.text = ""
         default:
             cell.textLabel.text = dateManager.conversionDateFormat(indexPath)
 
-            if dateAttributes.isThisMonth(day: cell.textLabel.text!, row:indexPath.row) {
-                if dateAttributes.existPosts(dayLabel: cell.textLabel.text!) {
-                    // 投稿があった日は太字 + 色を黒くする
-                    cell.textLabel.font = UIFont(name: "HiraKakuProN-W6", size: 11.5)
-                    cell.textLabel.textColor = UIColor.black
-                }
+            if (dateAttributes.existPosts(dayLabel: cell.textLabel.text!)) {
+                // 投稿があった日は太字 + 色を黒くする
+                cell.textLabel.font = UIFont(name: "HiraKakuProN-W6", size: 11.5)
+                cell.textLabel.textColor = UIColor.black
             }
         }
         return cell

--- a/sunset/Classes/Controllers/CalendarViewController.swift
+++ b/sunset/Classes/Controllers/CalendarViewController.swift
@@ -105,7 +105,6 @@ class CalendarViewController: UIViewController, UICollectionViewDataSource, UICo
 
     // cellをtapした直後のアクション
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        var cell: CalendarCell
         // 初回タップ
         if (appDelegate.prevIndexPath == nil) {
             if (dateManager.ShowDayIfInThisMonth(indexPath.row) != "") {
@@ -116,11 +115,11 @@ class CalendarViewController: UIViewController, UICollectionViewDataSource, UICo
         } else {
             if (dateManager.ShowDayIfInThisMonth(indexPath.row) != "") {
                 // Deselectの役割
-                cell = collectionView.cellForItem(at: appDelegate.prevIndexPath!)! as! CalendarCell
+                let cell: CalendarCell = collectionView.cellForItem(at: appDelegate.prevIndexPath!)! as! CalendarCell
                 cell.circleImageView.image = nil
-                appDelegate.prevIndexPath = indexPath
                 addCircleToCell(collectionView, indexPath: indexPath)
-                }
+                appDelegate.prevIndexPath = indexPath
+            }
         }
         
         let day = dateManager.ShowDayIfInThisMonth(indexPath.row)
@@ -128,7 +127,7 @@ class CalendarViewController: UIViewController, UICollectionViewDataSource, UICo
             let year: String = (self.appDelegate.targetDate?.components(separatedBy: "-")[0])!
             let month: String = (self.appDelegate.targetDate?.components(separatedBy: "-")[1])!
             self.appDelegate.targetDate = year + "-" + month + "-" + day
-        
+
             NotificationCenter.default.post(name: TapCalendarCellNotification, object: nil)
         }
     }
@@ -165,7 +164,7 @@ class CalendarViewController: UIViewController, UICollectionViewDataSource, UICo
 
     // 選択されたセルに円を付与する
     func addCircleToCell(_ collectionView: UICollectionView, indexPath: IndexPath) {
-        let cell = collectionView.cellForItem(at: indexPath)! as! CalendarCell
+        let cell: CalendarCell = collectionView.cellForItem(at: indexPath)! as! CalendarCell
         cell.circleImageView.image = UIImage(named: "circle")
     }
 }

--- a/sunset/Classes/Controllers/CalendarViewController.swift
+++ b/sunset/Classes/Controllers/CalendarViewController.swift
@@ -115,6 +115,7 @@ class CalendarViewController: UIViewController, UICollectionViewDataSource, UICo
         // 2回目以降
         } else {
             if (dateManager.ShowDayIfInThisMonth(indexPath.row) != "") {
+                // Deselectの役割
                 cell = collectionView.cellForItem(at: appDelegate.prevIndexPath!)! as! CalendarCell
                 cell.circleImageView.image = nil
                 appDelegate.prevIndexPath = indexPath
@@ -162,6 +163,7 @@ class CalendarViewController: UIViewController, UICollectionViewDataSource, UICo
         calendarCollectionView.reloadData()
     }
 
+    // 選択されたセルに円を付与する
     func addCircleToCell(_ collectionView: UICollectionView, indexPath: IndexPath) {
         let cell = collectionView.cellForItem(at: indexPath)! as! CalendarCell
         cell.circleImageView.image = UIImage(named: "circle")

--- a/sunset/Classes/Helpers/DateAttributes.swift
+++ b/sunset/Classes/Helpers/DateAttributes.swift
@@ -28,18 +28,16 @@ class DateAttributes {
             return true
         }
     }
-    
-    // 表示されている日がその月のものかどうかを返す
-    func isThisMonth(day: String, row: Int) -> Bool {
-        if (row < 7) {
-            if (Int(day)! > 7) {
-                return false
-            } else if (row > 28) {
-                if (Int(day)! < 7) {
-                    return false
-                }
-            }
+
+    // 曜日の色の振り分け
+    func choiceDaysColor(row: Int) -> UIColor {
+        switch (row % 7) {
+        case 0:
+            return UIColor.red
+        case 6:
+            return UIColor.blue
+        default:
+            return UIColor.white
         }
-        return true
     }
 }

--- a/sunset/Classes/Views/CalendarCell.swift
+++ b/sunset/Classes/Views/CalendarCell.swift
@@ -25,5 +25,7 @@ class CalendarCell: UICollectionViewCell {
     override func prepareForReuse() {
         self.circleImageView.image = nil
         self.textLabel.font = UIFont(name: "HirakakuProN-W3", size: 11.5)
+        let appDelegate: AppDelegate = UIApplication.shared.delegate as! AppDelegate
+        appDelegate.prevIndexPath = nil
     }
 }


### PR DESCRIPTION
### 概要
- セルの表示の都合上、先月の最終週及び、次月の最初の週も表示されるようになっておりますが、その部分を削除します
### 内容
- カレンダーの表示内容の変更
- タップ時のimageViewの動作の変更
  - ちなみに現在: 曜日以外のどの日付のセルも円で囲まれる状態
