### PR TITLE
ナビゲーションバーの移動ボタンの大きさを調整する

### DIFF
--- a/sunset/Classes/Controllers/ViewController.swift
+++ b/sunset/Classes/Controllers/ViewController.swift
@@ -3,9 +3,9 @@ import UIKit
 @IBDesignable
 class ViewController: UIViewController {
 
-    @IBOutlet weak var headerPrevBtn: UIBarButtonItem!
-    @IBOutlet weak var headerNextBtn: UIBarButtonItem!
 
+    @IBOutlet weak var headerPrevBtn: UIButton!
+    @IBOutlet weak var headerNextBtn: UIButton!
     let appDelegate: AppDelegate = UIApplication.shared.delegate as! AppDelegate
     let formatter = DateFormatter()
     let TapPrevBtnNotification = Notification.Name("TapPrevBtn")

--- a/sunset/Storyboards/Main.storyboard
+++ b/sunset/Storyboards/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11201" systemVersion="15G1004" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="aqD-JG-Vi7">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11201" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="aqD-JG-Vi7">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
@@ -54,42 +54,50 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="rRI-CP-B7K">
-                        <barButtonItem key="leftBarButtonItem" style="done" id="ipd-Tl-rf2">
-                            <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="Eow-aZ-slC">
-                                <rect key="frame" x="16" y="7" width="83" height="30"/>
+                        <barButtonItem key="leftBarButtonItem" style="done" id="X0h-Py-8SW">
+                            <view key="customView" contentMode="scaleToFill" id="uUL-8w-Vc1">
+                                <rect key="frame" x="16" y="5" width="83" height="33"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="25"/>
-                                <state key="normal" title="←">
-                                    <color key="titleColor" red="1" green="0.5" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                </state>
-                                <connections>
-                                    <action selector="tappedPrevMonthBtn:" destination="BYZ-38-t0r" eventType="touchUpInside" id="uT3-4i-Ufb"/>
-                                </connections>
-                            </button>
-                            <connections>
-                                <action selector="tappedPrevMonthBtn:" destination="BYZ-38-t0r" id="JUa-aZ-FLT"/>
-                            </connections>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TSo-Jl-uZx">
+                                        <frame key="frameInset" minX="18" minY="1" width="46" height="30"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="25"/>
+                                        <state key="normal" title="←">
+                                            <color key="titleColor" red="1" green="0.5" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                        </state>
+                                        <connections>
+                                            <action selector="tappedPrevMonthBtn:" destination="BYZ-38-t0r" eventType="touchUpInside" id="bow-1h-S9V"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                            </view>
                         </barButtonItem>
-                        <barButtonItem key="rightBarButtonItem" style="done" id="Tgd-dE-bW3">
-                            <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="cj0-A2-FeU">
-                                <rect key="frame" x="276" y="7" width="83" height="30"/>
+                        <barButtonItem key="rightBarButtonItem" style="done" id="Hgw-Y3-FUT">
+                            <view key="customView" contentMode="scaleToFill" id="gVI-YW-0ys">
+                                <rect key="frame" x="276" y="5" width="83" height="33"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="25"/>
-                                <state key="normal" title="→">
-                                    <color key="titleColor" red="1" green="0.5" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                </state>
-                                <connections>
-                                    <action selector="tappedNextMonthBtn:" destination="BYZ-38-t0r" eventType="touchUpInside" id="taV-zy-ayo"/>
-                                </connections>
-                            </button>
-                            <connections>
-                                <action selector="tappedNextMonthBtn:" destination="BYZ-38-t0r" id="4Os-sl-qDh"/>
-                            </connections>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BJW-NE-Gt5">
+                                        <frame key="frameInset" minX="18" minY="1" width="46" height="30"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="25"/>
+                                        <state key="normal" title="→">
+                                            <color key="titleColor" red="1" green="0.5" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                        </state>
+                                        <connections>
+                                            <action selector="tappedNextMonthBtn:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Z9w-2L-dmZ"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                            </view>
                         </barButtonItem>
                     </navigationItem>
                     <connections>
-                        <outlet property="headerNextBtn" destination="Tgd-dE-bW3" id="oDc-sh-em6"/>
-                        <outlet property="headerPrevBtn" destination="ipd-Tl-rf2" id="PIa-07-lWa"/>
+                        <outlet property="headerNextBtn" destination="BJW-NE-Gt5" id="fN5-ot-HKU"/>
+                        <outlet property="headerPrevBtn" destination="TSo-Jl-uZx" id="Yvv-Ub-jTC"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
@@ -109,7 +117,7 @@
                                 <rect key="frame" x="0.0" y="28" width="375" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="raw-TQ-c9E" id="5Vy-z7-txt">
-                                    <frame key="frameInset" width="375" height="44"/>
+                                    <frame key="frameInset" width="375" height="43"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </tableViewCellContentView>
                                 <connections>


### PR DESCRIPTION
### 概要

ナビバーのボタンが割りと広く誤タップしちゃうことがあるので、表示されているボタンとタップ可領域を合わせます。
